### PR TITLE
Sugestão de teste para e-mail

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,18 @@ verifique a necessidade de ajustes no `.env.example`.
 
     php artisan dusk
 
+### Testando envio de e-mails utilizando a plataforma Mailtrap
+
+Utilizando a plataforma [Mailtrap](https://mailtrap.io/) é possível capturar os e-mails enviados sem que estes cheguem à caixa de entrada dos destinatários, possibilitando assim testar e analisar o envio de e-mails antes de se colocar em produção.
+
+__Como Utilizar__
+    
+Após criar e entrar com uma conta na plataforma, é possível gerar as credenciais para o envio de e-mail no sistema utilizado, no caso do Laravel as credenciais seriam semelhantes à figura a seguir:
+
+![image](https://user-images.githubusercontent.com/47902146/206538191-1b75750d-819b-4bc6-a8cf-efd7b8bf993b.png)
+
+Assim, basta substituir tais credenciais no `.env` do projeto e enviar os e-mails normalmente que estes serão capturados na caixa de entrada do Mailtrap, sem serem enviados aos seus destinatários.
+
 ## Histórico
 
 * 15/12/2022


### PR DESCRIPTION
Foi adicionado no README.md uma sugestão para realizar testes de envio de e-mail utilizando a plataforma Mailtrap.

Fix #6 